### PR TITLE
feat: image routing

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,5 +1,9 @@
 # Netlify redirects file, edit with your domain
 # https://www.netlify.com/docs/redirects/
 
-https://gatsby-starter-ghost.netlify.com/*      https://gatsby.ghost.org/:splat    301!
-http://gatsby-starter-ghost.netlify.com/*       https://gatsby.ghost.org/:splat    301!
+https://pixely-ghost.netlify.app/*      https://pixely.co.uk/:splat    301!
+http://pixely-ghost.netlify.app/*       https://pixely.co.uk/:splat    301!
+
+# Route images via Cloudinary allowing for dynamic image transformations
+# Based on https://twitter.com/philhawksworth/status/1328340868726726656
+/content/images/* transform=:transform       https://res.cloudinary.com/pixely-web/image/fetch/:transform/https://ghost.pixely.co.uk/content/images/:splat    200


### PR DESCRIPTION
This PR adds in Netlify redirect rules for images to ensure they go via Cloudinary's image transformation endpoints. This is in preparation for the 11ty version of this site.