### PR TITLE
Decision log embeds

### DIFF
--- a/src/_includes/embeds/decision-logs/documentation-branches.liquid
+++ b/src/_includes/embeds/decision-logs/documentation-branches.liquid
@@ -1,32 +1,32 @@
 <svg class="decision-log" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="346px" viewBox="-0.5 -0.5 831 346">
-   <defs/>
-   <g>
-      <rect x="81" y="143" width="120" height="60" class="decision-log__box" />
-      <rect x="355" y="143" width="120" height="60" class="decision-log__box" />
-      <rect x="355" y="213" width="120" height="60" class="decision-log__box" />
-      <rect x="355" y="73" width="120" height="60" class="decision-log__box" />
-      <rect x="506" y="73" width="120" height="60" class="decision-log__box decision-log--fade-1" />
-      <rect x="506" y="143" width="120" height="60" class="decision-log__box decision-log--fade-1" />
-      <rect x="657" y="143" width="120" height="60" class="decision-log__box decision-log--fade-2" />
-      <text x="141" y="177" class="decision-log__text" font-size="12px" text-anchor="middle">Living Documentation</text>
-      <text x="415" y="177" class="decision-log__text" font-size="12px" text-anchor="middle">Decision Log</text>
-      <text x="415" y="247" class="decision-log__text" font-size="12px" text-anchor="middle">Decision Log</text>
-      <text x="415" y="107" class="decision-log__text" font-size="12px" text-anchor="middle">Decision Log</text>
-      <text x="566" y="107" class="decision-log__text" font-size="12px" text-anchor="middle">Decision Log&hellip;</text>
-      <text x="566" y="177" class="decision-log__text" font-size="12px" text-anchor="middle">Decision Log&hellip;</text>
-      <text x="717" y="177" class="decision-log__text" font-size="12px" text-anchor="middle">Decision Log&hellip;</text>
-      <path d="M 503.76 103 L 495.76 107 L 495.76 99 Z" class="decision-log__arrow-head decision-log--fade-1" />
-      <path d="M 475 103 L 495.76 103" class="decision-log__arrow decision-log--fade-1" />
-      <path d="M 475 173 L 495.76 173" class="decision-log__arrow decision-log--fade-1" />
-      <path d="M 503.76 173 L 495.76 177 L 495.76 169 Z" class="decision-log__arrow-head decision-log--fade-1" />
-      <path d="M 626 173 L 646.76 173" class="decision-log__arrow decision-log--fade-2" />
-      <path d="M 654.76 173 L 646.76 177 L 646.76 169 Z" class="decision-log__arrow-head decision-log--fade-2" />
-      <path d="M 201 173 L 344.76 173" class="decision-log__arrow" />
-      <path d="M 201 173 Q 278 173 278 208 Q 278 243 344.76 243" class="decision-log__arrow" />
-      <path d="M 201 173 Q 278 173 278 138 Q 278 103 344.76 103" class="decision-log__arrow" />
-      <path d="M 352.76 173 L 344.76 177 L 344.76 169 Z" class="decision-log__arrow-head" />
-      <path d="M 352.76 243 L 344.76 247 L 344.76 239 Z" class="decision-log__arrow-head" />
-      <path d="M 352.76 103 L 344.76 107 L 344.76 99 Z" class="decision-log__arrow-head" />
-   </g>
+   <rect x="81" y="143" width="120" height="60" class="decision-log__box" />
+   <rect x="355" y="143" width="120" height="60" class="decision-log__box" />
+   <rect x="355" y="213" width="120" height="60" class="decision-log__box" />
+   <rect x="355" y="73" width="120" height="60" class="decision-log__box" />
+   <rect x="506" y="73" width="120" height="60" class="decision-log__box decision-log--fade-1" />
+   <rect x="506" y="143" width="120" height="60" class="decision-log__box decision-log--fade-1" />
+   <rect x="657" y="143" width="120" height="60" class="decision-log__box decision-log--fade-2" />
+   <text x="141" y="177" class="decision-log__text" font-size="12px">
+      <tspan x="141" dy="-.6em">Living</tspan>
+      <tspan x="141" dy="1.2em">Documentation</tspan>
+   </text>
+   <text x="415" y="177" class="decision-log__text" font-size="12px">Decision Log</text>
+   <text x="415" y="247" class="decision-log__text" font-size="12px">Decision Log</text>
+   <text x="415" y="107" class="decision-log__text" font-size="12px">Decision Log</text>
+   <text x="566" y="107" class="decision-log__text" font-size="12px">Decision Log</text>
+   <text x="566" y="177" class="decision-log__text" font-size="12px">Decision Log</text>
+   <text x="717" y="177" class="decision-log__text" font-size="12px">Decision Log</text>
+   <path d="M 503.76 103 L 495.76 107 L 495.76 99 Z" class="decision-log__arrow-head decision-log--fade-1" />
+   <path d="M 475 103 L 495.76 103" class="decision-log__arrow decision-log--fade-1" />
+   <path d="M 475 173 L 495.76 173" class="decision-log__arrow decision-log--fade-1" />
+   <path d="M 503.76 173 L 495.76 177 L 495.76 169 Z" class="decision-log__arrow-head decision-log--fade-1" />
+   <path d="M 626 173 L 646.76 173" class="decision-log__arrow decision-log--fade-2" />
+   <path d="M 654.76 173 L 646.76 177 L 646.76 169 Z" class="decision-log__arrow-head decision-log--fade-2" />
+   <path d="M 201 173 L 344.76 173" class="decision-log__arrow" />
+   <path d="M 201 173 Q 278 173 278 208 Q 278 243 344.76 243" class="decision-log__arrow" />
+   <path d="M 201 173 Q 278 173 278 138 Q 278 103 344.76 103" class="decision-log__arrow" />
+   <path d="M 352.76 173 L 344.76 177 L 344.76 169 Z" class="decision-log__arrow-head" />
+   <path d="M 352.76 243 L 344.76 247 L 344.76 239 Z" class="decision-log__arrow-head" />
+   <path d="M 352.76 103 L 344.76 107 L 344.76 99 Z" class="decision-log__arrow-head" />
 </svg>
 <link data-helmet="decision-log" rel="stylesheet" href="/styles/embeds/decision-log.css" />

--- a/src/_includes/embeds/decision-logs/documentation-branches.liquid
+++ b/src/_includes/embeds/decision-logs/documentation-branches.liquid
@@ -1,0 +1,32 @@
+<svg class="decision-log" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="346px" viewBox="-0.5 -0.5 831 346">
+   <defs/>
+   <g>
+      <rect x="81" y="143" width="120" height="60" class="decision-log__box" />
+      <rect x="355" y="143" width="120" height="60" class="decision-log__box" />
+      <rect x="355" y="213" width="120" height="60" class="decision-log__box" />
+      <rect x="355" y="73" width="120" height="60" class="decision-log__box" />
+      <rect x="506" y="73" width="120" height="60" class="decision-log__box decision-log--fade-1" />
+      <rect x="506" y="143" width="120" height="60" class="decision-log__box decision-log--fade-1" />
+      <rect x="657" y="143" width="120" height="60" class="decision-log__box decision-log--fade-2" />
+      <text x="141" y="177" class="decision-log__text" font-size="12px" text-anchor="middle">Living Documentation</text>
+      <text x="415" y="177" class="decision-log__text" font-size="12px" text-anchor="middle">Decision Log</text>
+      <text x="415" y="247" class="decision-log__text" font-size="12px" text-anchor="middle">Decision Log</text>
+      <text x="415" y="107" class="decision-log__text" font-size="12px" text-anchor="middle">Decision Log</text>
+      <text x="566" y="107" class="decision-log__text" font-size="12px" text-anchor="middle">Decision Log&hellip;</text>
+      <text x="566" y="177" class="decision-log__text" font-size="12px" text-anchor="middle">Decision Log&hellip;</text>
+      <text x="717" y="177" class="decision-log__text" font-size="12px" text-anchor="middle">Decision Log&hellip;</text>
+      <path d="M 503.76 103 L 495.76 107 L 495.76 99 Z" class="decision-log__arrow-head decision-log--fade-1" />
+      <path d="M 475 103 L 495.76 103" class="decision-log__arrow decision-log--fade-1" />
+      <path d="M 475 173 L 495.76 173" class="decision-log__arrow decision-log--fade-1" />
+      <path d="M 503.76 173 L 495.76 177 L 495.76 169 Z" class="decision-log__arrow-head decision-log--fade-1" />
+      <path d="M 626 173 L 646.76 173" class="decision-log__arrow decision-log--fade-2" />
+      <path d="M 654.76 173 L 646.76 177 L 646.76 169 Z" class="decision-log__arrow-head decision-log--fade-2" />
+      <path d="M 201 173 L 344.76 173" class="decision-log__arrow" />
+      <path d="M 201 173 Q 278 173 278 208 Q 278 243 344.76 243" class="decision-log__arrow" />
+      <path d="M 201 173 Q 278 173 278 138 Q 278 103 344.76 103" class="decision-log__arrow" />
+      <path d="M 352.76 173 L 344.76 177 L 344.76 169 Z" class="decision-log__arrow-head" />
+      <path d="M 352.76 243 L 344.76 247 L 344.76 239 Z" class="decision-log__arrow-head" />
+      <path d="M 352.76 103 L 344.76 107 L 344.76 99 Z" class="decision-log__arrow-head" />
+   </g>
+</svg>
+<link data-helmet="decision-log" rel="stylesheet" href="/styles/embeds/decision-log.css" />

--- a/src/_includes/embeds/decision-logs/documentation-map.liquid
+++ b/src/_includes/embeds/decision-logs/documentation-map.liquid
@@ -1,0 +1,62 @@
+<svg class="decision-log" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="346px" viewBox="-0.5 -0.5 831 346">
+   <g>
+      <rect x="355" y="18" width="120" height="60" class="decision-log__box" />
+      <text x="415" y="52" class="decision-log__text" class="decision-log__text" text-anchor="middle">Decision Log</text>
+      <path d="M 415 88.24 Q 415 88.24 415 257.76" class="decision-log__arrow decision-log__arrow--dashed" />
+      <path d="M 415 80.24 L 419 88.24 L 411 88.24 Z" class="decision-log__arrow-head" />
+      <path d="M 415 265.76 L 411 257.76 L 419 257.76 Z" class="decision-log__arrow-head" />
+      <rect x="355" y="268" width="120" height="60" class="decision-log__box" />
+      <text x="415" y="302" class="decision-log__text" class="decision-log__text" text-anchor="middle">Tickets</text>
+      <rect x="525" y="195.5" width="120" height="60" class="decision-log__box" />
+      <text x="585" y="229" class="decision-log__text" class="decision-log__text" text-anchor="middle">Design System</text>
+      <rect x="525" y="90.5" width="120" height="60" class="decision-log__box" />
+      <text x="585" y="124" class="decision-log__text" class="decision-log__text" text-anchor="middle">Living Technical Documentation</text>
+      <rect x="185" y="195.5" width="120" height="60" class="decision-log__box" />
+      <text x="245" y="229" class="decision-log__text" class="decision-log__text" text-anchor="middle">Meeting Notes</text>
+      <rect x="185" y="90.5" width="120" height="60" class="decision-log__box" />
+      <text x="245" y="124" class="decision-log__text" class="decision-log__text" text-anchor="middle">Living Documentation</text>
+      <path d="M 415 88.24 Q 415 225.5 514.76 225.5" class="decision-log__arrow decision-log__arrow--dashed" />
+      <path d="M 415 80.24 L 419 88.24 L 411 88.24 Z" class="decision-log__arrow-head" />
+      <path d="M 522.76 225.5 L 514.76 229.5 L 514.76 221.5 Z" class="decision-log__arrow-head" />
+      <path d="M 415 88.24 Q 415 120.5 514.76 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+      <path d="M 415 80.24 L 419 88.24 L 411 88.24 Z" class="decision-log__arrow-head" />
+      <path d="M 522.76 120.5 L 514.76 124.5 L 514.76 116.5 Z" class="decision-log__arrow-head" />
+      <path d="M 415 88.24 Q 415 120.5 315.24 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+      <path d="M 415 80.24 L 419 88.24 L 411 88.24 Z" class="decision-log__arrow-head" />
+      <path d="M 307.24 120.5 L 315.24 116.5 L 315.24 124.5 Z" class="decision-log__arrow-head" />
+      <path d="M 415 88.24 Q 415 225.5 315.24 225.5" class="decision-log__arrow decision-log__arrow--dashed" />
+      <path d="M 415 80.24 L 419 88.24 L 411 88.24 Z" class="decision-log__arrow-head" />
+      <path d="M 307.24 225.5 L 315.24 221.5 L 315.24 229.5 Z" class="decision-log__arrow-head" />
+      <path d="M 415 257.76 Q 415 225.5 315.24 225.5" class="decision-log__arrow decision-log__arrow--dashed" />
+      <path d="M 415 265.76 L 411 257.76 L 419 257.76 Z" class="decision-log__arrow-head" />
+      <path d="M 307.24 225.5 L 315.24 221.5 L 315.24 229.5 Z" class="decision-log__arrow-head" />
+      <path d="M 415 257.76 Q 415 225.5 514.76 225.5" class="decision-log__arrow decision-log__arrow--dashed" />
+      <path d="M 415 265.76 L 411 257.76 L 419 257.76 Z" class="decision-log__arrow-head" />
+      <path d="M 522.76 225.5 L 514.76 229.5 L 514.76 221.5 Z" class="decision-log__arrow-head" />
+      <path d="M 415 257.76 Q 415 120.5 514.76 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+      <path d="M 415 265.76 L 411 257.76 L 419 257.76 Z" class="decision-log__arrow-head" />
+      <path d="M 522.76 120.5 L 514.76 124.5 L 514.76 116.5 Z" class="decision-log__arrow-head" />
+      <path d="M 415 257.76 Q 415 120.5 315.24 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+      <path d="M 415 265.76 L 411 257.76 L 419 257.76 Z" class="decision-log__arrow-head" />
+      <path d="M 307.24 120.5 L 315.24 116.5 L 315.24 124.5 Z" class="decision-log__arrow-head" />
+      <path d="M 315.24 225.5 Q 325 225.5 325 173 Q 325 120.5 315.24 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+      <path d="M 307.24 225.5 L 315.24 221.5 L 315.24 229.5 Z" class="decision-log__arrow-head" />
+      <path d="M 307.24 120.5 L 315.24 116.5 L 315.24 124.5 Z" class="decision-log__arrow-head" />
+      <path d="M 514.76 225.5 Q 505 225.5 505 173 Q 505 120.5 514.76 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+      <path d="M 522.76 225.5 L 514.76 229.5 L 514.76 221.5 Z" class="decision-log__arrow-head" />
+      <path d="M 522.76 120.5 L 514.76 124.5 L 514.76 116.5 Z" class="decision-log__arrow-head" />
+      <path d="M 514.76 225.5 Q 415 225.5 415 173 Q 415 120.5 315.24 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+      <path d="M 522.76 225.5 L 514.76 229.5 L 514.76 221.5 Z" class="decision-log__arrow-head" />
+      <path d="M 307.24 120.5 L 315.24 116.5 L 315.24 124.5 Z" class="decision-log__arrow-head" />
+      <path d="M 315.24 225.5 Q 415 225.5 415 173 Q 415 120.5 514.76 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+      <path d="M 307.24 225.5 L 315.24 221.5 L 315.24 229.5 Z" class="decision-log__arrow-head" />
+      <path d="M 522.76 120.5 L 514.76 124.5 L 514.76 116.5 Z" class="decision-log__arrow-head" />
+      <path d="M 315.24 225.5 Q 315.24 225.5 514.76 225.5" class="decision-log__arrow decision-log__arrow--dashed" />
+      <path d="M 307.24 225.5 L 315.24 221.5 L 315.24 229.5 Z" class="decision-log__arrow-head" />
+      <path d="M 522.76 225.5 L 514.76 229.5 L 514.76 221.5 Z" class="decision-log__arrow-head" />
+      <path d="M 315.24 120.5 Q 315.24 120.5 514.76 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+      <path d="M 307.24 120.5 L 315.24 116.5 L 315.24 124.5 Z" class="decision-log__arrow-head" />
+      <path d="M 522.76 120.5 L 514.76 124.5 L 514.76 116.5 Z" class="decision-log__arrow-head" />
+   </g>
+</svg>
+<link data-helmet="decision-log" rel="stylesheet" href="/styles/embeds/decision-log.css" />

--- a/src/_includes/embeds/decision-logs/documentation-map.liquid
+++ b/src/_includes/embeds/decision-logs/documentation-map.liquid
@@ -1,62 +1,66 @@
 <svg class="decision-log" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="346px" viewBox="-0.5 -0.5 831 346">
-   <g>
-      <rect x="355" y="18" width="120" height="60" class="decision-log__box" />
-      <text x="415" y="52" class="decision-log__text" class="decision-log__text" text-anchor="middle">Decision Log</text>
-      <path d="M 415 88.24 Q 415 88.24 415 257.76" class="decision-log__arrow decision-log__arrow--dashed" />
-      <path d="M 415 80.24 L 419 88.24 L 411 88.24 Z" class="decision-log__arrow-head" />
-      <path d="M 415 265.76 L 411 257.76 L 419 257.76 Z" class="decision-log__arrow-head" />
-      <rect x="355" y="268" width="120" height="60" class="decision-log__box" />
-      <text x="415" y="302" class="decision-log__text" class="decision-log__text" text-anchor="middle">Tickets</text>
-      <rect x="525" y="195.5" width="120" height="60" class="decision-log__box" />
-      <text x="585" y="229" class="decision-log__text" class="decision-log__text" text-anchor="middle">Design System</text>
-      <rect x="525" y="90.5" width="120" height="60" class="decision-log__box" />
-      <text x="585" y="124" class="decision-log__text" class="decision-log__text" text-anchor="middle">Living Technical Documentation</text>
-      <rect x="185" y="195.5" width="120" height="60" class="decision-log__box" />
-      <text x="245" y="229" class="decision-log__text" class="decision-log__text" text-anchor="middle">Meeting Notes</text>
-      <rect x="185" y="90.5" width="120" height="60" class="decision-log__box" />
-      <text x="245" y="124" class="decision-log__text" class="decision-log__text" text-anchor="middle">Living Documentation</text>
-      <path d="M 415 88.24 Q 415 225.5 514.76 225.5" class="decision-log__arrow decision-log__arrow--dashed" />
-      <path d="M 415 80.24 L 419 88.24 L 411 88.24 Z" class="decision-log__arrow-head" />
-      <path d="M 522.76 225.5 L 514.76 229.5 L 514.76 221.5 Z" class="decision-log__arrow-head" />
-      <path d="M 415 88.24 Q 415 120.5 514.76 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
-      <path d="M 415 80.24 L 419 88.24 L 411 88.24 Z" class="decision-log__arrow-head" />
-      <path d="M 522.76 120.5 L 514.76 124.5 L 514.76 116.5 Z" class="decision-log__arrow-head" />
-      <path d="M 415 88.24 Q 415 120.5 315.24 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
-      <path d="M 415 80.24 L 419 88.24 L 411 88.24 Z" class="decision-log__arrow-head" />
-      <path d="M 307.24 120.5 L 315.24 116.5 L 315.24 124.5 Z" class="decision-log__arrow-head" />
-      <path d="M 415 88.24 Q 415 225.5 315.24 225.5" class="decision-log__arrow decision-log__arrow--dashed" />
-      <path d="M 415 80.24 L 419 88.24 L 411 88.24 Z" class="decision-log__arrow-head" />
-      <path d="M 307.24 225.5 L 315.24 221.5 L 315.24 229.5 Z" class="decision-log__arrow-head" />
-      <path d="M 415 257.76 Q 415 225.5 315.24 225.5" class="decision-log__arrow decision-log__arrow--dashed" />
-      <path d="M 415 265.76 L 411 257.76 L 419 257.76 Z" class="decision-log__arrow-head" />
-      <path d="M 307.24 225.5 L 315.24 221.5 L 315.24 229.5 Z" class="decision-log__arrow-head" />
-      <path d="M 415 257.76 Q 415 225.5 514.76 225.5" class="decision-log__arrow decision-log__arrow--dashed" />
-      <path d="M 415 265.76 L 411 257.76 L 419 257.76 Z" class="decision-log__arrow-head" />
-      <path d="M 522.76 225.5 L 514.76 229.5 L 514.76 221.5 Z" class="decision-log__arrow-head" />
-      <path d="M 415 257.76 Q 415 120.5 514.76 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
-      <path d="M 415 265.76 L 411 257.76 L 419 257.76 Z" class="decision-log__arrow-head" />
-      <path d="M 522.76 120.5 L 514.76 124.5 L 514.76 116.5 Z" class="decision-log__arrow-head" />
-      <path d="M 415 257.76 Q 415 120.5 315.24 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
-      <path d="M 415 265.76 L 411 257.76 L 419 257.76 Z" class="decision-log__arrow-head" />
-      <path d="M 307.24 120.5 L 315.24 116.5 L 315.24 124.5 Z" class="decision-log__arrow-head" />
-      <path d="M 315.24 225.5 Q 325 225.5 325 173 Q 325 120.5 315.24 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
-      <path d="M 307.24 225.5 L 315.24 221.5 L 315.24 229.5 Z" class="decision-log__arrow-head" />
-      <path d="M 307.24 120.5 L 315.24 116.5 L 315.24 124.5 Z" class="decision-log__arrow-head" />
-      <path d="M 514.76 225.5 Q 505 225.5 505 173 Q 505 120.5 514.76 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
-      <path d="M 522.76 225.5 L 514.76 229.5 L 514.76 221.5 Z" class="decision-log__arrow-head" />
-      <path d="M 522.76 120.5 L 514.76 124.5 L 514.76 116.5 Z" class="decision-log__arrow-head" />
-      <path d="M 514.76 225.5 Q 415 225.5 415 173 Q 415 120.5 315.24 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
-      <path d="M 522.76 225.5 L 514.76 229.5 L 514.76 221.5 Z" class="decision-log__arrow-head" />
-      <path d="M 307.24 120.5 L 315.24 116.5 L 315.24 124.5 Z" class="decision-log__arrow-head" />
-      <path d="M 315.24 225.5 Q 415 225.5 415 173 Q 415 120.5 514.76 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
-      <path d="M 307.24 225.5 L 315.24 221.5 L 315.24 229.5 Z" class="decision-log__arrow-head" />
-      <path d="M 522.76 120.5 L 514.76 124.5 L 514.76 116.5 Z" class="decision-log__arrow-head" />
-      <path d="M 315.24 225.5 Q 315.24 225.5 514.76 225.5" class="decision-log__arrow decision-log__arrow--dashed" />
-      <path d="M 307.24 225.5 L 315.24 221.5 L 315.24 229.5 Z" class="decision-log__arrow-head" />
-      <path d="M 522.76 225.5 L 514.76 229.5 L 514.76 221.5 Z" class="decision-log__arrow-head" />
-      <path d="M 315.24 120.5 Q 315.24 120.5 514.76 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
-      <path d="M 307.24 120.5 L 315.24 116.5 L 315.24 124.5 Z" class="decision-log__arrow-head" />
-      <path d="M 522.76 120.5 L 514.76 124.5 L 514.76 116.5 Z" class="decision-log__arrow-head" />
-   </g>
+   <rect x="355" y="18" width="120" height="60" class="decision-log__box" />
+   <text x="415" y="52" class="decision-log__text" class="decision-log__text">Decision Logs</text>
+   <path d="M 415 88.24 Q 415 88.24 415 257.76" class="decision-log__arrow decision-log__arrow--dashed" />
+   <path d="M 415 80.24 L 419 88.24 L 411 88.24 Z" class="decision-log__arrow-head" />
+   <path d="M 415 265.76 L 411 257.76 L 419 257.76 Z" class="decision-log__arrow-head" />
+   <rect x="355" y="268" width="120" height="60" class="decision-log__box" />
+   <text x="415" y="302" class="decision-log__text" class="decision-log__text">Tickets</text>
+   <rect x="525" y="195.5" width="120" height="60" class="decision-log__box" />
+   <text x="585" y="229" class="decision-log__text" class="decision-log__text">Design System</text>
+   <rect x="525" y="90.5" width="120" height="60" class="decision-log__box" />
+   <text x="585" y="124" class="decision-log__text" class="decision-log__text">
+      <tspan x="585" dy="-.6em">Code</tspan>
+      <tspan x="585" dy="1.2em">Documentation</tspan>
+   </text>
+   <rect x="185" y="195.5" width="120" height="60" class="decision-log__box" />
+   <text x="245" y="229" class="decision-log__text" class="decision-log__text">Meeting Notes</text>
+   <rect x="185" y="90.5" width="120" height="60" class="decision-log__box" />
+   <text x="245" y="124" class="decision-log__text" class="decision-log__text">
+      <tspan x="245" dy="-.6em">Living</tspan>
+      <tspan x="245" dy="1.2em">Documentation</tspan>
+   </text>
+   <path d="M 415 88.24 Q 415 225.5 514.76 225.5" class="decision-log__arrow decision-log__arrow--dashed" />
+   <path d="M 415 80.24 L 419 88.24 L 411 88.24 Z" class="decision-log__arrow-head" />
+   <path d="M 522.76 225.5 L 514.76 229.5 L 514.76 221.5 Z" class="decision-log__arrow-head" />
+   <path d="M 415 88.24 Q 415 120.5 514.76 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+   <path d="M 415 80.24 L 419 88.24 L 411 88.24 Z" class="decision-log__arrow-head" />
+   <path d="M 522.76 120.5 L 514.76 124.5 L 514.76 116.5 Z" class="decision-log__arrow-head" />
+   <path d="M 415 88.24 Q 415 120.5 315.24 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+   <path d="M 415 80.24 L 419 88.24 L 411 88.24 Z" class="decision-log__arrow-head" />
+   <path d="M 307.24 120.5 L 315.24 116.5 L 315.24 124.5 Z" class="decision-log__arrow-head" />
+   <path d="M 415 88.24 Q 415 225.5 315.24 225.5" class="decision-log__arrow decision-log__arrow--dashed" />
+   <path d="M 415 80.24 L 419 88.24 L 411 88.24 Z" class="decision-log__arrow-head" />
+   <path d="M 307.24 225.5 L 315.24 221.5 L 315.24 229.5 Z" class="decision-log__arrow-head" />
+   <path d="M 415 257.76 Q 415 225.5 315.24 225.5" class="decision-log__arrow decision-log__arrow--dashed" />
+   <path d="M 415 265.76 L 411 257.76 L 419 257.76 Z" class="decision-log__arrow-head" />
+   <path d="M 307.24 225.5 L 315.24 221.5 L 315.24 229.5 Z" class="decision-log__arrow-head" />
+   <path d="M 415 257.76 Q 415 225.5 514.76 225.5" class="decision-log__arrow decision-log__arrow--dashed" />
+   <path d="M 415 265.76 L 411 257.76 L 419 257.76 Z" class="decision-log__arrow-head" />
+   <path d="M 522.76 225.5 L 514.76 229.5 L 514.76 221.5 Z" class="decision-log__arrow-head" />
+   <path d="M 415 257.76 Q 415 120.5 514.76 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+   <path d="M 415 265.76 L 411 257.76 L 419 257.76 Z" class="decision-log__arrow-head" />
+   <path d="M 522.76 120.5 L 514.76 124.5 L 514.76 116.5 Z" class="decision-log__arrow-head" />
+   <path d="M 415 257.76 Q 415 120.5 315.24 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+   <path d="M 415 265.76 L 411 257.76 L 419 257.76 Z" class="decision-log__arrow-head" />
+   <path d="M 307.24 120.5 L 315.24 116.5 L 315.24 124.5 Z" class="decision-log__arrow-head" />
+   <path d="M 315.24 225.5 Q 325 225.5 325 173 Q 325 120.5 315.24 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+   <path d="M 307.24 225.5 L 315.24 221.5 L 315.24 229.5 Z" class="decision-log__arrow-head" />
+   <path d="M 307.24 120.5 L 315.24 116.5 L 315.24 124.5 Z" class="decision-log__arrow-head" />
+   <path d="M 514.76 225.5 Q 505 225.5 505 173 Q 505 120.5 514.76 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+   <path d="M 522.76 225.5 L 514.76 229.5 L 514.76 221.5 Z" class="decision-log__arrow-head" />
+   <path d="M 522.76 120.5 L 514.76 124.5 L 514.76 116.5 Z" class="decision-log__arrow-head" />
+   <path d="M 514.76 225.5 Q 415 225.5 415 173 Q 415 120.5 315.24 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+   <path d="M 522.76 225.5 L 514.76 229.5 L 514.76 221.5 Z" class="decision-log__arrow-head" />
+   <path d="M 307.24 120.5 L 315.24 116.5 L 315.24 124.5 Z" class="decision-log__arrow-head" />
+   <path d="M 315.24 225.5 Q 415 225.5 415 173 Q 415 120.5 514.76 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+   <path d="M 307.24 225.5 L 315.24 221.5 L 315.24 229.5 Z" class="decision-log__arrow-head" />
+   <path d="M 522.76 120.5 L 514.76 124.5 L 514.76 116.5 Z" class="decision-log__arrow-head" />
+   <path d="M 315.24 225.5 Q 315.24 225.5 514.76 225.5" class="decision-log__arrow decision-log__arrow--dashed" />
+   <path d="M 307.24 225.5 L 315.24 221.5 L 315.24 229.5 Z" class="decision-log__arrow-head" />
+   <path d="M 522.76 225.5 L 514.76 229.5 L 514.76 221.5 Z" class="decision-log__arrow-head" />
+   <path d="M 315.24 120.5 Q 315.24 120.5 514.76 120.5" class="decision-log__arrow decision-log__arrow--dashed" />
+   <path d="M 307.24 120.5 L 315.24 116.5 L 315.24 124.5 Z" class="decision-log__arrow-head" />
+   <path d="M 522.76 120.5 L 514.76 124.5 L 514.76 116.5 Z" class="decision-log__arrow-head" />
 </svg>
 <link data-helmet="decision-log" rel="stylesheet" href="/styles/embeds/decision-log.css" />

--- a/src/_includes/embeds/decision-logs/documentation-structure.liquid
+++ b/src/_includes/embeds/decision-logs/documentation-structure.liquid
@@ -1,37 +1,34 @@
 <svg class="decision-log" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="347px" viewBox="-0.5 -0.5 831 347">
-   <defs/>
-   <g>
-      <rect x="125" y="23" width="210" height="300" class="decision-log__base" />
-      <rect x="495" y="23" width="210" height="300" class="decision-log__base" />
-      <rect x="507" y="283" width="120" height="10" class="decision-log__heading" />
-      <rect x="507" y="233" width="120" height="10" class="decision-log__heading" />
-      <rect x="507" y="183" width="120" height="10" class="decision-log__heading" />
-      <rect x="507" y="73" width="120" height="10" class="decision-log__heading" />
-      <rect x="507" y="113" width="120" height="10" class="decision-log__heading" />
-      <rect x="507" y="33" width="120" height="10" class="decision-log__heading" />
-      <rect x="507" y="298" width="5" height="5" class="decision-log__checkbox" />
-      <rect x="507" y="308" width="5" height="5" class="decision-log__checkbox" />
-      <rect x="517" y="299" width="80" height="3" class="decision-log__text" />
-      <rect x="517" y="309" width="80" height="3" class="decision-log__text" />
-      <path d="M 137 43 L 137 33" class="decision-log__cursor" stroke-width="2" stroke-miterlimit="10" />
-      <rect x="512" y="143" width="25" height="3" class="decision-log__pro" />
-      <rect x="512" y="148" width="25" height="3" class="decision-log__pro" />
-      <rect x="512" y="153" width="25" height="3" class="decision-log__pro" />
-      <rect x="512" y="158" width="25" height="3" class="decision-log__con" />
-      <rect x="512" y="163" width="25" height="3" class="decision-log__con" />
-      <rect x="512" y="168" width="25" height="3" class="decision-log__con" />
-      <rect x="542" y="143" width="25" height="3" class="decision-log__pro" />
-      <rect x="542" y="148" width="25" height="3" class="decision-log__pro" />
-      <rect x="542" y="153" width="25" height="3" class="decision-log__pro" />
-      <rect x="542" y="158" width="25" height="3" class="decision-log__pro" />
-      <rect x="542" y="163" width="25" height="3" class="decision-log__con" />
-      <rect x="542" y="168" width="25" height="3" class="decision-log__con" />
-      <rect x="572" y="143" width="25" height="3" class="decision-log__pro" />
-      <rect x="572" y="148" width="25" height="3" class="decision-log__pro" />
-      <rect x="572" y="153" width="25" height="3" class="decision-log__con" />
-      <rect x="572" y="158" width="25" height="3" class="decision-log__con" />
-      <rect x="572" y="163" width="25" height="3" class="decision-log__con" />
-      <rect x="572" y="168" width="25" height="3" class="decision-log__con" />
-   </g>
+   <rect x="125" y="23" width="210" height="300" class="decision-log__base" />
+   <rect x="495" y="23" width="210" height="300" class="decision-log__base" />
+   <rect x="507" y="283" width="120" height="10" class="decision-log__heading" />
+   <rect x="507" y="233" width="120" height="10" class="decision-log__heading" />
+   <rect x="507" y="183" width="120" height="10" class="decision-log__heading" />
+   <rect x="507" y="73" width="120" height="10" class="decision-log__heading" />
+   <rect x="507" y="113" width="120" height="10" class="decision-log__heading" />
+   <rect x="507" y="33" width="120" height="10" class="decision-log__heading" />
+   <rect x="507" y="298" width="5" height="5" class="decision-log__checkbox" />
+   <rect x="507" y="308" width="5" height="5" class="decision-log__checkbox" />
+   <rect x="517" y="299" width="80" height="3" class="decision-log__text" />
+   <rect x="517" y="309" width="80" height="3" class="decision-log__text" />
+   <path d="M 137 43 L 137 33" class="decision-log__cursor" stroke-width="2" stroke-miterlimit="10" />
+   <rect x="512" y="143" width="25" height="3" class="decision-log__pro" />
+   <rect x="512" y="148" width="25" height="3" class="decision-log__pro" />
+   <rect x="512" y="153" width="25" height="3" class="decision-log__pro" />
+   <rect x="512" y="158" width="25" height="3" class="decision-log__con" />
+   <rect x="512" y="163" width="25" height="3" class="decision-log__con" />
+   <rect x="512" y="168" width="25" height="3" class="decision-log__con" />
+   <rect x="542" y="143" width="25" height="3" class="decision-log__pro" />
+   <rect x="542" y="148" width="25" height="3" class="decision-log__pro" />
+   <rect x="542" y="153" width="25" height="3" class="decision-log__pro" />
+   <rect x="542" y="158" width="25" height="3" class="decision-log__pro" />
+   <rect x="542" y="163" width="25" height="3" class="decision-log__con" />
+   <rect x="542" y="168" width="25" height="3" class="decision-log__con" />
+   <rect x="572" y="143" width="25" height="3" class="decision-log__pro" />
+   <rect x="572" y="148" width="25" height="3" class="decision-log__pro" />
+   <rect x="572" y="153" width="25" height="3" class="decision-log__con" />
+   <rect x="572" y="158" width="25" height="3" class="decision-log__con" />
+   <rect x="572" y="163" width="25" height="3" class="decision-log__con" />
+   <rect x="572" y="168" width="25" height="3" class="decision-log__con" />
 </svg>
 <link data-helmet="decision-log" rel="stylesheet" href="/styles/embeds/decision-log.css" />

--- a/src/_includes/embeds/decision-logs/documentation-structure.liquid
+++ b/src/_includes/embeds/decision-logs/documentation-structure.liquid
@@ -1,0 +1,37 @@
+<svg class="decision-log" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="347px" viewBox="-0.5 -0.5 831 347">
+   <defs/>
+   <g>
+      <rect x="125" y="23" width="210" height="300" class="decision-log__base" />
+      <rect x="495" y="23" width="210" height="300" class="decision-log__base" />
+      <rect x="507" y="283" width="120" height="10" class="decision-log__heading" />
+      <rect x="507" y="233" width="120" height="10" class="decision-log__heading" />
+      <rect x="507" y="183" width="120" height="10" class="decision-log__heading" />
+      <rect x="507" y="73" width="120" height="10" class="decision-log__heading" />
+      <rect x="507" y="113" width="120" height="10" class="decision-log__heading" />
+      <rect x="507" y="33" width="120" height="10" class="decision-log__heading" />
+      <rect x="507" y="298" width="5" height="5" class="decision-log__checkbox" />
+      <rect x="507" y="308" width="5" height="5" class="decision-log__checkbox" />
+      <rect x="517" y="299" width="80" height="3" class="decision-log__text" />
+      <rect x="517" y="309" width="80" height="3" class="decision-log__text" />
+      <path d="M 137 43 L 137 33" class="decision-log__cursor" stroke-width="2" stroke-miterlimit="10" />
+      <rect x="512" y="143" width="25" height="3" class="decision-log__pro" />
+      <rect x="512" y="148" width="25" height="3" class="decision-log__pro" />
+      <rect x="512" y="153" width="25" height="3" class="decision-log__pro" />
+      <rect x="512" y="158" width="25" height="3" class="decision-log__con" />
+      <rect x="512" y="163" width="25" height="3" class="decision-log__con" />
+      <rect x="512" y="168" width="25" height="3" class="decision-log__con" />
+      <rect x="542" y="143" width="25" height="3" class="decision-log__pro" />
+      <rect x="542" y="148" width="25" height="3" class="decision-log__pro" />
+      <rect x="542" y="153" width="25" height="3" class="decision-log__pro" />
+      <rect x="542" y="158" width="25" height="3" class="decision-log__pro" />
+      <rect x="542" y="163" width="25" height="3" class="decision-log__con" />
+      <rect x="542" y="168" width="25" height="3" class="decision-log__con" />
+      <rect x="572" y="143" width="25" height="3" class="decision-log__pro" />
+      <rect x="572" y="148" width="25" height="3" class="decision-log__pro" />
+      <rect x="572" y="153" width="25" height="3" class="decision-log__con" />
+      <rect x="572" y="158" width="25" height="3" class="decision-log__con" />
+      <rect x="572" y="163" width="25" height="3" class="decision-log__con" />
+      <rect x="572" y="168" width="25" height="3" class="decision-log__con" />
+   </g>
+</svg>
+<link data-helmet="decision-log" rel="stylesheet" href="/styles/embeds/decision-log.css" />

--- a/src/styles/components/organisms/content/_content.scss
+++ b/src/styles/components/organisms/content/_content.scss
@@ -189,7 +189,7 @@
   td {
     text-align: left;
     padding: 10px;
-    font-size: 0.833rem;
+    font-size: .833rem;
     vertical-align: top;
   }
 

--- a/src/styles/components/organisms/content/_content.scss
+++ b/src/styles/components/organisms/content/_content.scss
@@ -176,6 +176,32 @@
       border-bottom: 1px solid var(--theme-primary-light);
     }
   }
+
+  table {
+    border-collapse: collapse;
+  }
+
+  thead th {
+    border-bottom: 2px solid var(--theme-secondary-dark);
+  }
+
+  th,
+  td {
+    text-align: left;
+    padding: 10px;
+    font-size: 0.833rem;
+    vertical-align: top;
+  }
+
+  th:not(:last-child),
+  td:not(:last-child) {
+    border-right: 1px solid var(--theme-secondary-normal);
+  }
+
+  tr:not(:last-child) td {
+    border-bottom: 1px solid var(--theme-secondary-normal);
+  }
+  
 }
 
 @media (min-width: 576px) {

--- a/src/styles/embeds/atomic-pyramid.scss
+++ b/src/styles/embeds/atomic-pyramid.scss
@@ -9,7 +9,7 @@
 .pyramid__layer,
 .pyramid__text {
   stroke: none;
-  fill: var(--theme-primary-light)
+  fill: var(--theme-primary-light);
 }
 
 .pyramid,
@@ -20,18 +20,18 @@
 }
 
 .pyramid--back {
-  fill: var(--theme-primary-dark)
+  fill: var(--theme-primary-dark);
 }
 
 .pyramid__text {
   font-family: $font-family-body-copy;
   fill: var(--theme-text-inverted);
-  font-size: 1.44rem
+  font-size: 1.44rem;
 }
   
 .pyramid__arrow {
   fill: var(--theme-secondary-dark);
-  stroke: var(--theme-secondary-dark)
+  stroke: var(--theme-secondary-dark);
 }
 
 .pyramid__arrow-text {

--- a/src/styles/embeds/decision-log.scss
+++ b/src/styles/embeds/decision-log.scss
@@ -58,6 +58,7 @@
         fill: var(--theme-text-secondary);
         font-size: 0.67rem;
         pointer-events: none;
+        text-anchor: middle;
     }
 
     &--fade-1 {

--- a/src/styles/embeds/decision-log.scss
+++ b/src/styles/embeds/decision-log.scss
@@ -1,87 +1,86 @@
 @import "../settings/tokens";
 
 .decision-log {
-    background: var(--theme-primary-normal);
-    height: auto;
-    width: 100%;
+  background: var(--theme-primary-normal);
+  height: auto;
+  width: 100%;
 
-    &__base {
-        fill: var(--theme-base);
+  &__base {
+    fill: var(--theme-base);
+  }
+
+  &__cursor {
+    animation: 1s cursorFade ease-in-out infinite;
+    stroke: var(--theme-tertiary);
+  }
+
+  &__heading {
+    fill: var(--theme-secondary-normal);
+  }
+
+  &__checkbox {
+    fill: #fff;
+  }
+
+  &__text {
+    fill: var(--theme-text-normal);
+  }
+
+  &__pro {
+    fill: darkolivegreen;
+  }
+
+  &__con {
+    fill: crimson;
+  }
+
+  &__arrow {
+    fill: none;
+    stroke: var(--theme-tertiary);
+    stroke-width: 2px;
+    stroke-miterlimit: 10;
+
+    &--dashed {
+      stroke-dasharray: 6 6;
     }
+  }
 
-    &__cursor {
-        animation: 1s cursorFade ease-in-out infinite;
-        stroke: var(--theme-tertiary);
-    }
+  &__arrow-head {
+    fill: var(--theme-tertiary);
+  }
 
-    &__heading {
-        fill: var(--theme-secondary-normal);
-    }
+  &__box {
+    fill: var(--theme-secondary-normal);
+  }
 
-    &__checkbox {
-        fill: #fff;
-    }
+  &__text {
+    font-family: $font-family-body-copy;
+    fill: var(--theme-text-secondary);
+    font-size: .67rem;
+    pointer-events: none;
+    text-anchor: middle;
+  }
 
-    &__text {
-        fill: var(--theme-text-normal);
-    }
+  &--fade-1 {
+    fill-opacity: .75;
+    stroke-opacity: .75;
+  }
 
-    &__pro {
-        fill: darkolivegreen;
-    }
-
-    &__con {
-        fill: crimson;
-    }
-
-    &__arrow {
-        fill: none;
-        stroke: var(--theme-tertiary);
-        stroke-width: 2px;
-        stroke-miterlimit: 10;
-
-        &--dashed {
-            stroke-dasharray: 6 6;
-        }
-    }
-
-    &__arrow-head {
-        fill: var(--theme-tertiary);
-    }
-
-    &__box {
-        fill: var(--theme-secondary-normal);
-    }
-
-    &__text {
-        font-family: $font-family-body-copy;
-        fill: var(--theme-text-secondary);
-        font-size: 0.67rem;
-        pointer-events: none;
-        text-anchor: middle;
-    }
-
-    &--fade-1 {
-        fill-opacity: .75;
-        stroke-opacity: .75;
-    }
-
-    &--fade-2 {
-        fill-opacity: .5;
-        stroke-opacity: .5;
-    }
+  &--fade-2 {
+    fill-opacity: .5;
+    stroke-opacity: .5;
+  }
 }
 
 @keyframes cursorFade {
 
-    0%,
-    100% {
-      opacity: 0;
-    }
-  
-    40%,
-    60% {
-      opacity: 1;
-    }
-  
+  0%,
+  100% {
+    opacity: 0;
   }
+  
+  40%,
+  60% {
+    opacity: 1;
+  }
+}

--- a/src/styles/embeds/decision-log.scss
+++ b/src/styles/embeds/decision-log.scss
@@ -33,6 +33,38 @@
     &__con {
         fill: crimson;
     }
+
+    &__arrow {
+        fill: none;
+        stroke: var(--theme-tertiary);
+        stroke-width: 2px;
+        stroke-miterlimit: 10;
+    }
+
+    &__arrow-head {
+        fill: var(--theme-tertiary);
+    }
+
+    &__box {
+        fill: var(--theme-secondary-normal);
+    }
+
+    &__text {
+        font-family: $font-family-body-copy;
+        fill: var(--theme-text-secondary);
+        // font-size: 1.44rem;
+        pointer-events: none;
+    }
+
+    &--fade-1 {
+        fill-opacity: .75;
+        stroke-opacity: .75;
+    }
+
+    &--fade-2 {
+        fill-opacity: .5;
+        stroke-opacity: .5;
+    }
 }
 
 @keyframes cursorFade {

--- a/src/styles/embeds/decision-log.scss
+++ b/src/styles/embeds/decision-log.scss
@@ -39,6 +39,10 @@
         stroke: var(--theme-tertiary);
         stroke-width: 2px;
         stroke-miterlimit: 10;
+
+        &--dashed {
+            stroke-dasharray: 6 6;
+        }
     }
 
     &__arrow-head {
@@ -52,7 +56,7 @@
     &__text {
         font-family: $font-family-body-copy;
         fill: var(--theme-text-secondary);
-        // font-size: 1.44rem;
+        font-size: 0.67rem;
         pointer-events: none;
     }
 

--- a/src/styles/embeds/decision-log.scss
+++ b/src/styles/embeds/decision-log.scss
@@ -1,0 +1,50 @@
+@import "../settings/tokens";
+
+.decision-log {
+    background: var(--theme-primary-normal);
+    height: auto;
+    width: 100%;
+
+    &__base {
+        fill: var(--theme-base);
+    }
+
+    &__cursor {
+        animation: 1s cursorFade ease-in-out infinite;
+        stroke: var(--theme-tertiary);
+    }
+
+    &__heading {
+        fill: var(--theme-secondary-normal);
+    }
+
+    &__checkbox {
+        fill: #fff;
+    }
+
+    &__text {
+        fill: var(--theme-text-normal);
+    }
+
+    &__pro {
+        fill: darkolivegreen;
+    }
+
+    &__con {
+        fill: crimson;
+    }
+}
+
+@keyframes cursorFade {
+
+    0%,
+    100% {
+      opacity: 0;
+    }
+  
+    40%,
+    60% {
+      opacity: 1;
+    }
+  
+  }


### PR DESCRIPTION
This PR adds additional SVGs and styling in support of [Documenting Architectural Decisions](https://pixely.co.uk/documenting-architectural-decisions/) blogpost

- 3 new SVG embeds (used inside the post)
- Generic table styling